### PR TITLE
vcrpy 8.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools >=61.2
     - pip
+    - wheel
   run:
     - python
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,6 @@
 {% set name = "vcrpy" %}
 {% set version = "8.3.0" %}
-{% set ignore_tests = " --ignore=tests/integration" %}
-{% set deselect_tests = " --deselect=tests/unit/test_unittest.py::test_testcase_playback" %}
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_stream"' %}
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_iterator"' %}
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_unittest.py::test_cassette_library_dir"' %}  # [win]
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_unittest.py::test_vcr_kwargs_cassette_dir"' %}  # [win]
 
-# E   ModuleNotFoundError: No module named 'pytest_httpbin'
-# E   fixture 'httpbin' not found
-# WIN path errors not found file with "/", neeeds "\\".
 package:
   name: {{ name }}
   version: {{ version }}
@@ -33,6 +24,15 @@ requirements:
     - pyyaml
     - wrapt
 
+# E   ModuleNotFoundError: No module named 'pytest_httpbin'
+{% set ignore_tests = " --ignore=tests/integration" %}
+# E   fixture 'httpbin' not found
+{% set deselect_tests = " --deselect=tests/unit/test_unittest.py::test_testcase_playback" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_stream" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_iterator" %}
+# WIN path errors not found file with "/", neeeds "\\".
+{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_unittest.py::test_cassette_library_dir" %}  # [win]
+{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_unittest.py::test_vcr_kwargs_cassette_dir" %}  # [win]
 test:
   source_files:
     - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,22 @@
 {% set name = "vcrpy" %}
-{% set version = "8.0.0" %}
+{% set version = "8.3.0" %}
+{% set ignore_tests = " --ignore=tests/integration" %}
+{% set deselect_tests = " --deselect=tests/unit/test_unittest.py::test_testcase_playback" %}
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_stream"' %}
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_iterator"' %}
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_unittest.py::test_cassette_library_dir"' %}  # [win]
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/unit/test_unittest.py::test_vcr_kwargs_cassette_dir"' %}  # [win]
 
+# E   ModuleNotFoundError: No module named 'pytest_httpbin'
+# E   fixture 'httpbin' not found
+# WIN path errors not found file with "/", neeeds "\\".
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 25622ec65c5c007597d417e6867ccb6e6ab0d5f8826e2a03feb5911b3011f8ad
+  sha256: 46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212
 
 build:
   number: 0
@@ -17,23 +26,13 @@ build:
 requirements:
   host:
     - python
-    - setuptools
+    - setuptools >=61.2
     - pip
-    - wheel
   run:
     - python
     - pyyaml
     - wrapt
 
-# E   ModuleNotFoundError: No module named 'pytest_httpbin'
-{% set ignore_tests = " --ignore=tests/integration" %}
-# E   fixture 'httpbin' not found
-{% set deselect_tests = " --deselect=tests/unit/test_unittest.py::test_testcase_playback" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_stream" %}
-{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_stubs.py::TestVCRConnection::test_body_consumed_once_iterator" %}
-# WIN path errors not found file with "/", neeeds "\\".
-{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_unittest.py::test_cassette_library_dir" %}  # [win]
-{% set deselect_tests = deselect_tests + " --deselect=tests/unit/test_unittest.py::test_vcr_kwargs_cassette_dir" %}  # [win]
 test:
   source_files:
     - tests


### PR DESCRIPTION
## Links
- Jira ticket: https://anaconda.atlassian.net/browse/PKG-16466
- Project Dev URL: https://github.com/kevin1024/vcrpy
- conda-forge recipe: https://github.com/conda-forge/vcrpy-feedstock
- PyPI: https://pypi.org/project/vcrpy/8.3.0
- PyPI Inspector: https://inspector.pypi.io/project/vcrpy/8.3.0

Bump vcrpy 8.0.0 → 8.3.0. Added `setuptools >=61.2` constraint to host (per pyproject.toml build-system requires); removed `wheel` from host (not declared as a build requirement upstream). Runtime deps (`pyyaml`, `wrapt`) unchanged.

## Notes
- Fixed a bug introduced by the automation's initial commit: the `ignore_tests`/`deselect_tests` Jinja block had been relocated to the top of the file and its string concatenation was mangled (wrapped in literal quotes), which would have broken the pytest deselection at test time. Restored to its correct position directly above the `test:` section with valid concatenation.
- conda-forge builds this package as `noarch: python`; this recipe intentionally keeps the existing per-Python-version build (`skip: py<310`) since this PR is a version bump, not a rebuild-strategy change.
